### PR TITLE
Add koala mapping scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Koala Activity Toolkit
+
+This repository contains simple tools for locating suitable areas for koala
+activities and planning routes. The examples rely on public APIs and Python.
+
+## Hotspot identification with the GBIF API
+
+The script `koala_map/hotspots.py` downloads occurrence records for several
+Eucalyptus species from the GBIF API. It aggregates the coordinates on a grid to
+highlight areas with many records and produces a heatmap.
+
+Usage:
+
+```bash
+python3 koala_map/hotspots.py
+```
+
+The script prints the ten most represented grid cells and creates an HTML map
+(`hotspots_map.html`). Internet access is required to contact the GBIF API.
+
+## Drawing and saving itineraries
+
+`koala_map/map_app.py` provides a tiny Flask application serving an interactive
+map (powered by Folium and Leaflet). You can draw lines or polygons on the map.
+Each new drawing triggers a POST request to `/save` that appends the GeoJSON
+geometry to a local `routes.json` file.
+
+Run the server with:
+
+```bash
+python3 koala_map/map_app.py
+```
+
+Then open `http://localhost:5000` in your browser to draw routes. The collected
+routes are stored in `routes.json`.
+
+## Uploading routes to GitHub
+
+`koala_map/github_upload.py` demonstrates how to push the `routes.json` file to a
+GitHub repository using the GitHub API. Set environment variables `GITHUB_TOKEN`
+(a personal access token) and `GITHUB_REPO` (e.g. `user/repo`) before running
+
+```bash
+python3 koala_map/github_upload.py
+```
+
+This will create or update `routes.json` in the specified repository.
+
+## Requirements
+
+- Python 3
+- `requests`
+- `folium`
+- `flask`
+
+Install dependencies with:
+
+```bash
+pip install requests folium flask
+```

--- a/koala_map/github_upload.py
+++ b/koala_map/github_upload.py
@@ -1,0 +1,30 @@
+import base64
+import requests
+
+
+def upload_file(token, repo, path, commit_message):
+    url = f"https://api.github.com/repos/{repo}/contents/{path}"
+    with open(path, "rb") as f:
+        content = base64.b64encode(f.read()).decode("utf-8")
+    data = {
+        "message": commit_message,
+        "content": content
+    }
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json"
+    }
+    r = requests.put(url, json=data, headers=headers)
+    r.raise_for_status()
+    return r.json()
+
+if __name__ == "__main__":
+    import os
+    token = os.environ.get("GITHUB_TOKEN")
+    repo = os.environ.get("GITHUB_REPO")
+    path = "routes.json"
+    if not token or not repo:
+        print("Set GITHUB_TOKEN and GITHUB_REPO environment variables")
+    else:
+        resp = upload_file(token, repo, path, "Upload new route")
+        print(resp)

--- a/koala_map/hotspots.py
+++ b/koala_map/hotspots.py
@@ -1,0 +1,63 @@
+import requests
+from collections import defaultdict
+import folium
+from folium.plugins import HeatMap
+
+GBIF_OCCURRENCE_URL = "https://api.gbif.org/v1/occurrence/search"
+
+def fetch_occurrences(species, limit=300):
+    params = {
+        "scientificName": species,
+        "hasCoordinate": "true",
+        "limit": limit
+    }
+    resp = requests.get(GBIF_OCCURRENCE_URL, params=params)
+    resp.raise_for_status()
+    data = resp.json()
+    coords = []
+    for rec in data.get("results", []):
+        lat = rec.get("decimalLatitude")
+        lon = rec.get("decimalLongitude")
+        if lat is not None and lon is not None:
+            coords.append((lat, lon))
+    return coords
+
+def grid_hotspots(coords, grid_size=1.0, top_n=10):
+    counts = defaultdict(int)
+    for lat, lon in coords:
+        cell = (round(lat / grid_size) * grid_size,
+                round(lon / grid_size) * grid_size)
+        counts[cell] += 1
+    sorted_cells = sorted(counts.items(), key=lambda x: x[1], reverse=True)
+    return [(cell[0], cell[1], count) for cell, count in sorted_cells[:top_n]]
+
+def create_heatmap(coords, output_html="hotspots_map.html"):
+    if not coords:
+        raise ValueError("No coordinates to plot")
+    center = [sum(p[0] for p in coords)/len(coords),
+              sum(p[1] for p in coords)/len(coords)]
+    m = folium.Map(location=center, zoom_start=5)
+    HeatMap(coords).add_to(m)
+    m.save(output_html)
+    return output_html
+
+if __name__ == "__main__":
+    species = [
+        "Eucalyptus globulus",
+        "Eucalyptus camaldulensis",
+        "Eucalyptus tereticornis",
+        "Eucalyptus robusta"
+    ]
+    all_coords = []
+    for sp in species:
+        print(f"Fetching occurrences for {sp}...")
+        try:
+            all_coords.extend(fetch_occurrences(sp))
+        except Exception as e:
+            print("Failed to fetch", sp, e)
+    print(f"Fetched {len(all_coords)} total occurrences")
+    hotspots = grid_hotspots(all_coords)
+    for lat, lon, count in hotspots:
+        print(f"Hotspot {lat}, {lon} - {count} records")
+    output = create_heatmap(all_coords)
+    print("Heatmap saved to", output)

--- a/koala_map/map_app.py
+++ b/koala_map/map_app.py
@@ -1,0 +1,57 @@
+from flask import Flask, render_template_string, request, jsonify
+import folium
+from folium.plugins import Draw
+import json
+import os
+
+app = Flask(__name__)
+ROUTE_FILE = "routes.json"
+
+HTML_TEMPLATE = """
+<!doctype html>
+<html>
+<head>
+<meta charset='utf-8'>
+<title>Koala Route Planner</title>
+<style>html, body {height: 100%; margin: 0;}</style>
+{{ folium_map|safe }}
+<script src='https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js'></script>
+<script>
+function setup() {
+  var map = window.map;
+  map.on('draw:created', function(e) {
+    var geojson = e.layer.toGeoJSON();
+    axios.post('/save', geojson).then(function() {
+      alert('Route saved');
+    });
+  });
+}
+if (window.map) { setup(); } else { document.addEventListener('DOMContentLoaded', setup); }
+</script>
+</head>
+<body></body>
+</html>
+"""
+
+@app.route('/')
+def index():
+    m = folium.Map(location=[-25, 133], zoom_start=4)
+    Draw(export=True).add_to(m)
+    html = m.get_root().render()
+    return render_template_string(HTML_TEMPLATE, folium_map=html)
+
+@app.route('/save', methods=['POST'])
+def save():
+    data = request.get_json()
+    if os.path.exists(ROUTE_FILE):
+        with open(ROUTE_FILE, 'r') as f:
+            routes = json.load(f)
+    else:
+        routes = []
+    routes.append(data)
+    with open(ROUTE_FILE, 'w') as f:
+        json.dump(routes, f, indent=2)
+    return jsonify({'status': 'ok'})
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- create basic tool for gathering GBIF occurrences and drawing hotspots
- add a tiny Flask app that allows drawing and saving routes
- provide a helper for uploading routes to GitHub
- document usage in a README

## Testing
- `python3 -m py_compile koala_map/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686aa61a1a98832caa1e6f83ef74c51c